### PR TITLE
History use improvements

### DIFF
--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -47,12 +47,12 @@ function renderHistory() {
     const q = document.createElement("div");
     q.className = "history-item";
     q.textContent = entry.query;
-    q.onclick = () => input.value = entry.query;
+    q.onclick = () => {input.value += entry.query; input.focus()};
     historyDiv.appendChild(q);
     const r = document.createElement("div");
     r.className = "history-item";
     r.textContent = entry.result;
-    r.onclick = () => input.value = entry.result;
+    r.onclick = () => {input.value += entry.result; input.focus()};
     historyDiv.appendChild(r);
   });
   historyDiv.scrollTop = historyDiv.scrollHeight;


### PR DESCRIPTION
Don't overwrite the input field when clicking on a result to insert it - instead append to the end. Also give focus back to the input field when something is clicked.

This is how CloudyCalc worked, and I think it makes more sense to insert the value inline, rather than entirely replace whatever was already there. That way it's easier to chain multiple past results together.